### PR TITLE
Fix/barcode redemption and refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: ruby
 env:
   matrix:
-    - SOLIDUS_BRANCH=v1.2 DB=mysql
-    - SOLIDUS_BRANCH=v1.2 DB=postgres
+    - SOLIDUS_BRANCH=v1.4 DB=mysql
+    - SOLIDUS_BRANCH=v1.4 DB=postgres
 rvm:
   - 2.1.8

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source "https://rubygems.org"
 
-branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
-gem "solidus", github: "solidusio/solidus", branch: branch
+gem 'solidus', github: 'solidusio/solidus', branch: 'v1.4'
 gem "solidus_auth_devise"
 
 gem 'pg'

--- a/app/controllers/spree/api/gift_cards_controller.rb
+++ b/app/controllers/spree/api/gift_cards_controller.rb
@@ -1,13 +1,10 @@
 class Spree::Api::GiftCardsController < Spree::Api::BaseController
-
   skip_before_action :authorize_for_order
 
   def redeem
-    @gift_card = Spree::VirtualGiftCard.active_by_redemption_code(redemption_code)
-
-    if !@gift_card
+    if gift_card.nil?
       render status: :not_found, json: redeem_fail_response
-    elsif @gift_card.redeem(@current_api_user)
+    elsif gift_card.redeem(@current_api_user)
       render status: :created, json: {}
     else
       render status: :unprocessable_entity, json: redeem_fail_response
@@ -15,7 +12,7 @@ class Spree::Api::GiftCardsController < Spree::Api::BaseController
   end
 
   def code_exists
-    if Spree::VirtualGiftCard.active_by_redemption_code(params[:redemption_code])
+    if gift_card
       head :ok
     else
       head :not_found
@@ -23,6 +20,11 @@ class Spree::Api::GiftCardsController < Spree::Api::BaseController
   end
 
   private
+
+  def gift_card
+    @gift_card = Spree::VirtualGiftCard.active_by_redemption_code(redemption_code) ||
+      Spree::GiftCardBarcode.active(redemption_code)
+  end
 
   def redeem_fail_response
    {

--- a/app/controllers/spree/api/gift_cards_controller.rb
+++ b/app/controllers/spree/api/gift_cards_controller.rb
@@ -23,7 +23,7 @@ class Spree::Api::GiftCardsController < Spree::Api::BaseController
 
   def gift_card
     @gift_card = Spree::VirtualGiftCard.active_by_redemption_code(redemption_code) ||
-      Spree::GiftCardBarcode.active(redemption_code)
+      Spree::GiftCardBarcode.active_by_redemption_code(redemption_code)
   end
 
   def redeem_fail_response

--- a/app/controllers/spree/gift_cards_controller.rb
+++ b/app/controllers/spree/gift_cards_controller.rb
@@ -1,0 +1,21 @@
+class Spree::GiftCardsController < Spree::StoreController
+  def redeem
+    redemption_code = Spree::RedemptionCodeGenerator.format_redemption_code_for_lookup(params[:redemption_code] || "")
+    @gift_card = Spree::VirtualGiftCard.active_by_redemption_code(redemption_code)
+    @gift_card = Spree::GiftCardBarcode.active_by_redemption_code(redemption_code) unless @gift_card
+
+    if @gift_card && @gift_card.redeem(try_spree_current_user)
+      flash[:success] = Spree.t('redeem.success')
+    else
+      flash[:error] = redeem_fail_response
+    end
+
+    redirect_to account_path(tab: 'credit')
+  end
+
+  private
+
+  def redeem_fail_response
+    "#{Spree.t('admin.gift_cards.errors.not_found')}. #{Spree.t('admin.gift_cards.errors.please_try_again')}"
+  end
+end

--- a/app/models/concerns/spree/gift_cards/flat_percent_item_total_calculator_concern.rb
+++ b/app/models/concerns/spree/gift_cards/flat_percent_item_total_calculator_concern.rb
@@ -1,0 +1,22 @@
+module Spree
+  module GiftCards::FlatPercentItemTotalCalculatorConcern
+    extend ActiveSupport::Concern
+
+    included do
+      prepend(InstanceMethods)
+    end
+
+    module InstanceMethods
+      def compute(object)
+        computed_amount = (object.amount_without_gift_cards * preferred_flat_percent / 100).round(2)
+        # We don't want to cause the promotion adjustments to push the order into a negative total.
+        if computed_amount > object.amount
+          object.amount
+        else
+          computed_amount
+        end
+      end
+    end
+  end
+end
+

--- a/app/models/concerns/spree/gift_cards/order_concerns.rb
+++ b/app/models/concerns/spree/gift_cards/order_concerns.rb
@@ -36,6 +36,14 @@ module Spree
           end
         end
       end
+
+      def non_gift_card_items
+        line_items.reject { |li| li.gift_card? }
+      end
+
+      def amount_without_gift_cards
+        non_gift_card_items.map(&:amount).sum
+      end
     end
   end
 end

--- a/app/models/spree/calculator/flat_percent_item_total_decorator.rb
+++ b/app/models/spree/calculator/flat_percent_item_total_decorator.rb
@@ -1,0 +1,1 @@
+Spree::Calculator::FlatPercentItemTotal.include Spree::GiftCards::FlatPercentItemTotalCalculatorConcern

--- a/app/models/spree/gift_card_barcode.rb
+++ b/app/models/spree/gift_card_barcode.rb
@@ -6,6 +6,9 @@ module Spree
     belongs_to :virtual_gift_card, class_name: 'Spree::VirtualGiftCard'
     belongs_to :order, class_name: 'Spree::Order'
 
+    delegate :store_credit, :purchaser, :redeemer, to: :virtual_gift_card, allow_nil: true
+    delegate :line_items, to: :order
+
     scope :unredeemed, -> { where(redeemed_at: nil) }
 
     self.whitelisted_ransackable_attributes = %w[number]
@@ -39,9 +42,9 @@ module Spree
 
     private
 
-    def redeem_associated_gift_card(redeemer)
+    def redeem_associated_gift_card(user)
       return if virtual_gift_card.nil?
-      virtual_gift_card.update_attributes(redeemed_at: Time.now, redeemer: redeemer)
+      virtual_gift_card.update_attributes(redeemed_at: Time.now, redeemer: user)
     end
   end
 end

--- a/app/models/spree/gift_card_barcode.rb
+++ b/app/models/spree/gift_card_barcode.rb
@@ -1,0 +1,48 @@
+module Spree
+  class GiftCardBarcode < Spree::Base
+    acts_as_paranoid
+    validates_uniqueness_of :number, unless: :deleted_at
+
+    belongs_to :virtual_gift_card, class_name: 'Spree::VirtualGiftCard'
+    belongs_to :order, class_name: 'Spree::Order'
+
+    scope :unredeemed, -> { where(redeemed_at: nil) }
+
+    self.whitelisted_ransackable_attributes = %w[number]
+
+    def sold!(gift_card, order)
+      self.order = order
+      self.virtual_gift_card = gift_card
+      self.sold_at = Time.now
+
+      save
+    end
+
+    def redeem(user)
+      return if redeemed?
+      user.store_credits.create!(amount: amount, category: store_credit_category, currency: 'USD', created_by: user)
+      redeem_associated_gift_card
+      update_attributes(redeemed_at: Time.now)
+    end
+
+    def store_credit_category
+      Spree::StoreCreditCategory.gift_card
+    end
+    
+
+    def redeemed?
+      redeemed_at.present?
+    end
+
+    def self.active(number)
+      Spree::GiftCardBarcode.unredeemed.find_by(number: number)
+    end
+
+    private
+
+    def redeem_associated_gift_card
+      return if virtual_gift_card.nil?
+      virtual_gift_card.update_attributes(redeemed_at: Time.now)
+    end
+  end
+end

--- a/app/models/spree/gift_card_barcode.rb
+++ b/app/models/spree/gift_card_barcode.rb
@@ -23,7 +23,7 @@ module Spree
 
     def redeem(user)
       return if redeemed?
-      user.store_credits.create!(amount: amount, category: store_credit_category, currency: virtual_gift_card&.currency, created_by: user)
+      user.store_credits.create!(amount: amount, category: store_credit_category, currency: currency, created_by: user)
       redeem_associated_gift_card(user)
       update_attributes(redeemed_at: Time.now)
     end
@@ -45,6 +45,10 @@ module Spree
     def redeem_associated_gift_card(user)
       return if virtual_gift_card.nil?
       virtual_gift_card.update_attributes(redeemed_at: Time.now, redeemer: user)
+    end
+
+    def currency
+      virtual_gift_card.present? ? virtual_gift_card.currency : Spree::Store.default.default_currency
     end
   end
 end

--- a/app/models/spree/gift_card_barcode.rb
+++ b/app/models/spree/gift_card_barcode.rb
@@ -20,8 +20,8 @@ module Spree
 
     def redeem(user)
       return if redeemed?
-      user.store_credits.create!(amount: amount, category: store_credit_category, currency: 'USD', created_by: user)
-      redeem_associated_gift_card
+      user.store_credits.create!(amount: amount, category: store_credit_category, currency: virtual_gift_card&.currency, created_by: user)
+      redeem_associated_gift_card(user)
       update_attributes(redeemed_at: Time.now)
     end
 
@@ -39,9 +39,9 @@ module Spree
 
     private
 
-    def redeem_associated_gift_card
+    def redeem_associated_gift_card(redeemer)
       return if virtual_gift_card.nil?
-      virtual_gift_card.update_attributes(redeemed_at: Time.now)
+      virtual_gift_card.update_attributes(redeemed_at: Time.now, redeemer: redeemer)
     end
   end
 end

--- a/app/models/spree/gift_card_barcode.rb
+++ b/app/models/spree/gift_card_barcode.rb
@@ -28,13 +28,12 @@ module Spree
     def store_credit_category
       Spree::StoreCreditCategory.gift_card
     end
-    
 
     def redeemed?
       redeemed_at.present?
     end
 
-    def self.active(number)
+    def self.active_by_redemption_code(number)
       Spree::GiftCardBarcode.unredeemed.find_by(number: number)
     end
 

--- a/app/models/spree/store_credit_category_decorator.rb
+++ b/app/models/spree/store_credit_category_decorator.rb
@@ -1,2 +1,20 @@
+module Spree
+  module StoreCreditCategoryExtensions
+    module ClassMethods
+      def gift_card
+        Spree::StoreCreditCategory.find_or_create_by(name: Spree::StoreCreditCategory::GIFT_CARD_CATEGORY_NAME)
+      end
+    end
+    
+    def self.prepended(base)
+      class << base
+        prepend ClassMethods
+      end
+    end
+  end
+end
+
+Spree::StoreCreditCategory.prepend Spree::StoreCreditCategoryExtensions
+
 Spree::StoreCreditCategory::GIFT_CARD_CATEGORY_NAME = "Gift Card".freeze
 Spree::StoreCreditCategory.non_expiring_credit_types |= [Spree::StoreCreditCategory::GIFT_CARD_CATEGORY_NAME]

--- a/app/models/spree/virtual_gift_card.rb
+++ b/app/models/spree/virtual_gift_card.rb
@@ -17,7 +17,7 @@ class Spree::VirtualGiftCard < Spree::Base
   scope :purchased, -> { where(redeemable: true) }
 
   self.whitelisted_ransackable_associations = %w[line_item order]
-  self.whitelisted_ransackable_attributes = %w[redemption_code recipient_email sent_at send_email_at]
+  self.whitelisted_ransackable_attributes = %w[redemption_code recipient_email sent_at send_email_at barcode]
 
   ransacker :sent_at do
     Arel.sql('date(sent_at)')
@@ -112,8 +112,14 @@ class Spree::VirtualGiftCard < Spree::Base
   end
 
   def send_email
+    return if physical?
+
     Spree::GiftCardMailer.gift_card_email(self).deliver_later
     update_attributes!(sent_at: DateTime.now)
+  end
+
+  def physical?
+    line_item.product.slug.include? 'physical-gift-card'
   end
 
   private

--- a/app/models/spree/virtual_gift_card.rb
+++ b/app/models/spree/virtual_gift_card.rb
@@ -104,7 +104,7 @@ class Spree::VirtualGiftCard < Spree::Base
   end
 
   def store_credit_category
-    Spree::StoreCreditCategory.where(name: Spree::StoreCreditCategory::GIFT_CARD_CATEGORY_NAME).first
+    Spree::StoreCreditCategory.gift_card
   end
 
   def self.active_by_redemption_code(redemption_code)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,10 @@
 Spree::Core::Engine.routes.draw do
+  resources :gift_cards, only: [] do
+    collection do
+      post :redeem
+    end
+  end
+
   namespace :admin do
     resources :users, only: [] do
       resources :gift_cards, only: [] do

--- a/db/migrate/20161114213243_add_barcode_to_virtual_gift_cards.rb
+++ b/db/migrate/20161114213243_add_barcode_to_virtual_gift_cards.rb
@@ -1,0 +1,6 @@
+class AddBarcodeToVirtualGiftCards < ActiveRecord::Migration
+  def change
+    add_column :spree_virtual_gift_cards, :barcode, :string
+    add_index :spree_virtual_gift_cards, :barcode, unique: true
+  end
+end

--- a/db/migrate/20161115155718_create_spree_gift_card_barcodes.rb
+++ b/db/migrate/20161115155718_create_spree_gift_card_barcodes.rb
@@ -1,0 +1,13 @@
+class CreateSpreeGiftCardBarcodes < ActiveRecord::Migration
+  def change
+    create_table :spree_gift_card_barcodes do |t|
+      t.references  :virtual_gift_card, :order
+      t.decimal     :amount, precision: 10, scale: 2, default: 0.0, null: false
+      t.string      :number, :string, unique: true
+      t.datetime    :sold_at
+      t.datetime    :deleted_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170103222409_add_redeemed_at_to_spree_gift_card_barcodes.rb
+++ b/db/migrate/20170103222409_add_redeemed_at_to_spree_gift_card_barcodes.rb
@@ -1,0 +1,7 @@
+class AddRedeemedAtToSpreeGiftCardBarcodes < ActiveRecord::Migration
+  def change
+    add_column :spree_gift_card_barcodes, :redeemed_at, :datetime
+
+    add_index :spree_gift_card_barcodes, :redeemed_at
+  end
+end

--- a/lib/spree_virtual_gift_card/factories.rb
+++ b/lib/spree_virtual_gift_card/factories.rb
@@ -25,13 +25,13 @@ FactoryGirl.define do
     end
   end
 
-  factory :gift_card_barcode, class: Spree::GiftCardBarcode do
-    association :virtual_gift_card, factory: :virtual_gift_card
+  factory :redeemable_gift_card_barcode, class: Spree::GiftCardBarcode do
+    association :virtual_gift_card, factory: :redeemable_virtual_gift_card
     amount 25.0
-    
+
     before(:create) do |bar_code, evaluator|
       bar_code.number = (0...16).map { (65 + rand(26)).chr }.join
     end
   end
-  
+
 end

--- a/lib/spree_virtual_gift_card/factories.rb
+++ b/lib/spree_virtual_gift_card/factories.rb
@@ -25,6 +25,12 @@ FactoryGirl.define do
     end
   end
 
+  factory :physical_gift_card, class: Spree::VirtualGiftCard, parent: :virtual_gift_card do
+    after(:create) do |gift_card|
+      gift_card.line_item.product.update_attributes(slug: 'physical-gift-card')
+    end
+  end
+
   factory :redeemable_gift_card_barcode, class: Spree::GiftCardBarcode do
     association :virtual_gift_card, factory: :redeemable_virtual_gift_card
     amount 25.0

--- a/lib/spree_virtual_gift_card/factories.rb
+++ b/lib/spree_virtual_gift_card/factories.rb
@@ -24,4 +24,14 @@ FactoryGirl.define do
       end
     end
   end
+
+  factory :gift_card_barcode, class: Spree::GiftCardBarcode do
+    association :virtual_gift_card, factory: :virtual_gift_card
+    amount 25.0
+    
+    before(:create) do |bar_code, evaluator|
+      bar_code.number = (0...16).map { (65 + rand(26)).chr }.join
+    end
+  end
+  
 end

--- a/solidus_virtual_gift_card.gemspec
+++ b/solidus_virtual_gift_card.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
   s.requirements << "none"
 
-  s.add_dependency "solidus", "~> 1.2"
+  s.add_dependency "solidus", [">= 1.4", "< 2"]
   s.add_dependency "deface"
 
   s.add_development_dependency "rspec-rails", "~> 3.2"

--- a/spec/controllers/spree/api/gift_cards_controller_spec.rb
+++ b/spec/controllers/spree/api/gift_cards_controller_spec.rb
@@ -7,6 +7,7 @@ describe Spree::Api::GiftCardsController do
 
   describe "POST redeem" do
     let(:gift_card) { create(:redeemable_virtual_gift_card) }
+    let(:barcode) { create(:gift_card_barcode) }
 
     let(:parameters) do
       {
@@ -14,7 +15,7 @@ describe Spree::Api::GiftCardsController do
       }
     end
 
-    subject { spree_post :redeem, parameters, { format: :json } }
+    subject { spree_post :redeem, parameters, { format: :json } }    
 
     context "the user is not logged in" do
 
@@ -91,6 +92,12 @@ describe Spree::Api::GiftCardsController do
         it "returns a 201" do
           subject
           expect(subject.status).to eq 201
+        end
+      end
+
+      context "there is a valid barcode number" do
+        it 'finds the barcode' do
+          spree_post :redeem, { redemption_code: barcode.number }, { format: :json }
         end
       end
     end

--- a/spec/lib/tasks/send_gift_card_emails_spec.rb
+++ b/spec/lib/tasks/send_gift_card_emails_spec.rb
@@ -14,7 +14,7 @@ describe "solidus_virtual_gift_card:send_current_emails" do
 
   context "with gift card sent today" do
     it "sends emails to be sent today" do
-      gift_card = Spree::VirtualGiftCard.create!(amount: 50, send_email_at: Date.today, redeemable: true, purchaser: purchaser)
+      gift_card = Spree::VirtualGiftCard.create!(amount: 50, send_email_at: Date.today, redeemable: true, purchaser: purchaser, line_item: create(:line_item))
       expect(Spree::GiftCardMailer).to receive(:gift_card_email).with(gift_card).and_return(double(deliver_later: true))
       subject
     end

--- a/spec/mailers/spree/gift_card_mailer_spec.rb
+++ b/spec/mailers/spree/gift_card_mailer_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Spree::GiftCardMailer, type: :mailer do
+describe Spree::GiftCardMailer, delay_jobs: false, type: :mailer do
   context '#gift_card_email' do
     let(:gift_card) { create(:redeemable_virtual_gift_card) }
 
@@ -15,6 +15,17 @@ describe Spree::GiftCardMailer, type: :mailer do
       it "uses the email associated with the order" do
         expect(subject.to).to contain_exactly('gift_card_tester@example.com')
       end
+    end
+  end
+
+  context 'physical gift cards' do
+    let(:physical_gift_card) { create(:physical_gift_card) }
+    let(:order) { create(:order_ready_to_complete, line_items: [physical_gift_card.line_item]) }
+
+    it 'does not send email when it is a physical gift card' do
+      order.complete!
+
+      expect(ActionMailer::Base.deliveries).to_not include(have_attributes(subject: ' has sent you a gift'))
     end
   end
 end

--- a/spec/models/spree/calculator/flat_percent_item_total_spec.rb
+++ b/spec/models/spree/calculator/flat_percent_item_total_spec.rb
@@ -5,7 +5,7 @@ describe Spree::Calculator::FlatPercentItemTotal, type: :model do
     promotion = Spree::Promotion.create!(name: "10% discount", apply_automatically: true)
 
     calculator = Spree::Calculator::FlatPercentItemTotal.new
-    calculator.preferred_flat_percent = 50
+    calculator.preferred_flat_percent = 10
 
     action = Spree::Promotion::Actions::CreateAdjustment.create
     action.calculator = calculator

--- a/spec/models/spree/calculator/flat_percent_item_total_spec.rb
+++ b/spec/models/spree/calculator/flat_percent_item_total_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe Spree::Calculator::FlatPercentItemTotal, type: :model do
+  let!(:promotion_two) do
+    promotion = Spree::Promotion.create!(name: "10% discount", apply_automatically: true)
+
+    calculator = Spree::Calculator::FlatPercentItemTotal.new
+    calculator.preferred_flat_percent = 50
+
+    action = Spree::Promotion::Actions::CreateAdjustment.create
+    action.calculator = calculator
+    action.save
+
+    promotion.actions << action
+  end
+
+  let(:gift_card) { create(:virtual_gift_card) }
+  let(:order) { create(:order_with_line_items, state: 'cart', line_items: [gift_card.line_item]) }
+
+  context "compute" do
+    it "should exclude gift cards from calculations" do
+      gift_card.line_item.product.update_column(:gift_card, true)
+      Spree::PromotionHandler::Cart.new(order).activate
+      order.update_totals
+      expect(order.promo_total).to eq -1.0
+    end
+  end
+end

--- a/spec/models/spree/virtual_gift_card_spec.rb
+++ b/spec/models/spree/virtual_gift_card_spec.rb
@@ -327,4 +327,22 @@ describe Spree::VirtualGiftCard do
       expect { subject }.to change { gift_card.sent_at }
     end
   end
+
+  describe "email notifications" do
+    it 'sends an email for virtual gift card' do
+      virtual_gift_card = create(:virtual_gift_card)
+
+      expect {
+        virtual_gift_card.send_email
+      }.to change{ ActionMailer::Base.deliveries.count }.by(1)
+    end
+
+    it 'does not send an email for physical gift card' do
+      physical_gift_card = create(:physical_gift_card)
+
+      expect {
+        physical_gift_card.send_email
+      }.not_to change{ ActionMailer::Base.deliveries.count }
+    end
+  end
 end

--- a/spec/requests/spree/gift_cards_controller_specs.rb
+++ b/spec/requests/spree/gift_cards_controller_specs.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+RSpec.describe Spree::GiftCardsController do
+  let!(:barcode) { create(:redeemable_gift_card_barcode) }
+  let!(:gift_card) { create(:redeemable_virtual_gift_card, redemption_code: 'DEF456', amount: 20, redeemable: true) }
+  let!(:current_user) { create(:user, email: 'georges@glossier.com') }
+  let!(:store_credit_category) { Spree::StoreCreditCategory.gift_card }
+  let!(:credit_type) { create(:secondary_credit_type) }
+
+  before do
+    allow_any_instance_of(Spree::StoreController).to receive_messages(try_spree_current_user: current_user)
+  end
+
+  context 'Virtual Card' do
+    it 'redeems a gift card using the redemption code' do
+      post '/gift_cards/redeem', redemption_code: gift_card.redemption_code
+
+      expect(gift_card.reload).to be_redeemed
+      expect(current_user.store_credits).to include(have_attributes(amount: 20, category: Spree::StoreCreditCategory.gift_card))
+    end
+  end
+
+  context 'Physical Card' do
+    it 'redeems a physical gift card using the barcode' do
+      post '/gift_cards/redeem', redemption_code: barcode.number
+
+      expect(barcode.reload).to be_redeemed
+      expect(current_user.store_credits).to include(have_attributes(amount: 25, category: Spree::StoreCreditCategory.gift_card))
+    end
+
+    it 'redeems the associated gift card when present' do
+      barcode.update_attribute(:virtual_gift_card, gift_card)
+
+      post '/gift_cards/redeem', redemption_code: barcode.number
+
+      expect(gift_card.reload).to be_redeemed
+      expect(current_user.store_credits).to contain_exactly(have_attributes(amount: 25, category: Spree::StoreCreditCategory.gift_card))
+    end
+
+    it 'does not allow a user to redeem multiple times the same code' do
+      barcode.update_column(:redeemed_at, Time.now)
+
+      post '/gift_cards/redeem', redemption_code: barcode.number
+
+      expect(current_user.store_credits).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
- migrations to support physical / barcode were added 
- convenience method to check if a virtual gift card is a physical one
- whitelist attribute `barcode` for ransack
- created `GiftCardBarcode` active model to support physical gift cards
- created regular controller to support redeeming of both virtual and physical gift cards
- add support for the api endpoint that allows redeeming of physical gift cards
- bump up solidus version support to 1.4
- decorator for the `FlatItemPercentTotal` to exclude GC from the promos
- physical GC does not send out email notification

Specs created for:
- regular gift card controller to handle both virtual and physical gift card - https://github.com/glossier/solidus_virtual_gift_card/pull/2/files#diff-0cf9c2e5dd5dc902db5586d43c0ade32
- additional specs to tests the email notification for physical gift cards created - https://github.com/glossier/solidus_virtual_gift_card/pull/2/files#diff-93b45eda70f5ec197bb0bea3b1402a61
- specs to test the api for redeeming physical/barcoded gift cards - https://github.com/glossier/solidus_virtual_gift_card/pull/2/files#diff-077c56918060d2680b0fcb088ba8eb1b
- additional factories to support testing of physical/barcoded gift cards - https://github.com/glossier/solidus_virtual_gift_card/pull/2/files#diff-789f664fc5030869829f68e8645f7a87
- specs to test the `FlatItemPercentTotal` - https://github.com/glossier/solidus_virtual_gift_card/blob/daa9e6b43c3ec8085a95abcb3659b21569d22ab3/spec/models/spree/calculator/flat_percent_item_total_spec.rb
- specs to test that physical gc does not send out email notifications -
 https://github.com/glossier/solidus_virtual_gift_card/blob/daa9e6b43c3ec8085a95abcb3659b21569d22ab3/spec/mailers/spree/gift_card_mailer_spec.rb