### PR TITLE
Support in OrderContents#update_cart for Multiple Line-Items

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,8 @@ branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
 gem "solidus", github: "solidusio/solidus", branch: branch
 gem "solidus_auth_devise"
 
-gem 'pg'
-gem 'mysql2'
+gem 'pg', '~> 0.21'
+gem 'mysql2', '~> 0.4.9'
 
 group :test, :development do
   gem 'pry-rails'

--- a/app/models/concerns/spree/gift_cards/order_contents_concerns.rb
+++ b/app/models/concerns/spree/gift_cards/order_contents_concerns.rb
@@ -23,10 +23,18 @@ module Spree
       def update_cart(params)
         update_success = super(params)
 
-        if update_success && params[:line_items_attributes]
-          line_item = Spree::LineItem.find_by(id: params[:line_items_attributes][:id])
-          new_quantity = params[:line_items_attributes][:quantity].to_i
-          update_gift_cards(line_item, new_quantity)
+        if update_success && line_item_attributes = params[:line_items_attributes]
+
+          [line_item_attributes].flatten.each do |attrs|
+            new_quantity = attrs[:quantity].to_i
+            line_item = if attrs.key?(:id)
+                          order.line_items.find_by(id: attrs[:id])
+                        elsif attrs.key?(:variant_id)
+                          order.line_items.find_by(variant_id: attrs[:variant_id])
+                        end
+
+            update_gift_cards(line_item, new_quantity)
+          end
         end
 
         update_success

--- a/solidus_virtual_gift_card.gemspec
+++ b/solidus_virtual_gift_card.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "sass-rails"
   s.add_development_dependency "coffee-rails"
   s.add_development_dependency "factory_girl"
-  s.add_development_dependency "capybara"
+  s.add_development_dependency "capybara", "~> 2"
   s.add_development_dependency "poltergeist"
   s.add_development_dependency "database_cleaner"
   s.add_development_dependency "ffaker"

--- a/spec/models/spree/order_contents_spec.rb
+++ b/spec/models/spree/order_contents_spec.rb
@@ -266,5 +266,26 @@ describe Spree::OrderContents do
         end
       end
     end
+
+    context "when adding more than one gift-card simultaneously" do
+      let(:variant2) { create(:variant) }
+
+      let(:update_params) do
+        {
+          line_items_attributes: [
+            { variant_id: variant.id, quantity: quantity, options: {} },
+            { variant_id: variant2.id, quantity: quantity, options: {} }
+          ]
+        }
+      end
+
+      before do
+        [variant, variant2].each { |v| v.product.update_attributes(gift_card: true) }
+      end
+
+      it "adds multiple line-items" do
+        expect { subject }.to change { order.line_items.count }.by(2)
+      end
+    end
   end
 end


### PR DESCRIPTION
Because the order model in the base Solidus framework accepts nested attributes for line-items, it's possible to add _multiple_ line-items to an order simultaneously via OrderContents#update_cart. However, the virtual gift-cards decoration of this method doesn't support this usage. This PR proposes to adjust the method so that it does!